### PR TITLE
Fix stylish-haskell target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,23 @@
-.PHONY: ide stylish-haskell hlint
+HASKELL_SRC=$(shell find src/ -type f -name '*.hs')
+HASKELL_TEST=$(shell find test/ -type f -name '*.hs')
+HASKELL_EXAMPLES=$(shell find examples/ -type f -name '*.hs')
 
+.PHONY: ide
 ide:
 	ghcid --command "stack ghci --ghci-options=-fno-code"
 
+.PHONY: watch-docs
 watch-docs:
 	stack haddock servant-docs-simple --no-haddock-deps --file-watch --fast
 
+.PHONY: docs
 docs:
 	stack haddock servant-docs-simple --no-haddock-deps --fast --open
 
-stylish-haskell:
-	stylish-haskell src/**/*.hs test/**/*.hs examples/*.hs -i
+.PHONY: stylish-haskell
+stylish-haskell: $(HASKELL_SRC) $(HASKELL_TEST) $(HASKELL_EXAMPLES)
+	stylish-haskell $^ -i
 
+.PHONY: hlint
 hlint:
 	hlint -h .hlint.yaml test src examples


### PR DESCRIPTION
This fixes stylish Haskell target in makefile and adds few other improvements based on best practices.

## Why this didin't work before

Make doesn't perform wildcard expansion like shell does. This means that `stylish-haskell src/**/*.hs test/**/*.hs examples/*.hs -i` literary means a file which includes `*` in its name. There are several ways around this, the simplest being using `$(shell...)` but this requires at least bash 4.0 (since we would need `-O globstar`) which I don't believe is what MacOS ships with. Using `find` is relatively old school but well supported.

`$^` means all the inputs. Inputs are the things listed after `:` so in this case results of running the 3 find commands. I'm also adding `.PHONY` as these commands are not expected to produce file with the name of the target on FS and so leaving out `.PHONY` might lead to problematic behavior.