### PR TITLE
Improve how type-level lists are rendered (closes #8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ type Response = Post '[()] ()
 
 main :: IO ()
 main = do
-  -- Writes to the file $PWD/docsJson
+  -- Writes to the file $PWD/docs.json
   writeDocsJson @API "docs.json"
 
-  -- Writes to the file $PWD/docsPlainText
+  -- Writes to the file $PWD/docs.txt
   writeDocsPlainText @API "docs.txt"
 
 ```
@@ -75,12 +75,12 @@ docs.txt
 {
     "/hello/world": {
         "Response": {
-            "Format": "': * () ('[] *)",
+            "Format": "[()]",
             "ContentType": "()"
         },
         "RequestType": "'POST",
         "RequestBody": {
-            "Format": "': * () ('[] *)",
+            "Format": "[()]",
             "ContentType": "()"
         }
     }
@@ -92,11 +92,11 @@ docs.txt
 ``` text
 /hello/world:
 RequestBody:
-    Format: ': * () ('[] *)
+    Format: [()]
     ContentType: ()
 RequestType: 'POST
 Response:
-    Format: ': * () ('[] *)
+    Format: [()]
     ContentType: ()
 ```
 
@@ -138,7 +138,7 @@ stack examples/<source file>
     --                                           --- Format Types ---
     --                                          |                    |
     --                                          v                    v
-    type singleAPI = "hello" :> ReqBody '[JSON] User :> POST '[JSON] Message
+    type SingleAPI = "hello" :> ReqBody '[JSON] User :> POST '[JSON] Message
     data User = User Name Password deriving Typeable 
     data Messsage = Message Id Content deriving Typeable
 

--- a/examples/example.hs
+++ b/examples/example.hs
@@ -16,8 +16,8 @@ type Response = Post '[()] ()
 
 main :: IO ()
 main = do
-  -- Writes to the file $PWD/docsJson
+  -- Writes to the file $PWD/docs.json
   writeDocsJson @API "docs.json"
 
-  -- Writes to the file $PWD/docsPlainText
+  -- Writes to the file $PWD/docs.txt
   writeDocsPlainText @API "docs.txt"

--- a/src/Servant/Docs/Simple.hs
+++ b/src/Servant/Docs/Simple.hs
@@ -24,10 +24,10 @@ __Example script__
 >
 > main :: IO ()
 > main = do
->   -- Writes to the file $PWD/docsJson
+>   -- Writes to the file $PWD/docs.json
 >   writeDocsJson @API "docs.json"
 >
->   -- Writes to the file $PWD/docsPlainText
+>   -- Writes to the file $PWD/docs.txt
 >   writeDocsPlainText @API "docs.txt"
 
 __Expected Output__
@@ -43,12 +43,12 @@ __Expected Output__
 > {
 >     "/hello/world": {
 >         "Response": {
->             "Format": "': * () ('[] *)",
+>             "Format": "[()]",
 >             "ContentType": "()"
 >         },
 >         "RequestType": "'POST",
 >         "RequestBody": {
->             "Format": "': * () ('[] *)",
+>             "Format": "[()]",
 >             "ContentType": "()"
 >         }
 >     }
@@ -58,11 +58,11 @@ __Expected Output__
 
 > /hello/world:
 > RequestBody:
->     Format: ': * () ('[] *)
+>     Format: [()]
 >     ContentType: ()
 > RequestType: 'POST
 > Response:
->     Format: ': * () ('[] *)
+>     Format: [()]
 >     ContentType: ()
 
 -}

--- a/src/Servant/Docs/Simple/Render.hs
+++ b/src/Servant/Docs/Simple/Render.hs
@@ -13,7 +13,7 @@ __Example of rendering the intermediate structure__
 > ApiDocs ( fromList [( "/hello/world",
 >                     , Details (fromList ([ ( "RequestBody"
 >                                            , Details (fromList ([ ( "Format"
->                                                                   , Detail "': * () ('[] *)"
+>                                                                   , Detail "[()]"
 >                                                                   )
 >                                                                 , ( "ContentType"
 >                                                                   , Detail "()"
@@ -25,7 +25,7 @@ __Example of rendering the intermediate structure__
 >                                            )
 >                                          , ( "Response"
 >                                            , Details (fromList ([ ( "Format"
->                                                                   , Detail "': * () ('[] *)"
+>                                                                   , Detail "[()]"
 >                                                                   )
 >                                                                 , ( "ContentType"
 >                                                                   , Detail "()"
@@ -41,12 +41,12 @@ __Example of rendering the intermediate structure__
 > {
 >     "/hello/world": {
 >         "Response": {
->             "Format": "': * () ('[] *)",
+>             "Format": "[()]",
 >             "ContentType": "()"
 >         },
 >         "RequestType": "'POST",
 >         "RequestBody": {
->             "Format": "': * () ('[] *)",
+>             "Format": "[()]",
 >             "ContentType": "()"
 >         }
 >     }
@@ -56,11 +56,11 @@ __Example of rendering the intermediate structure__
 
 > /hello/world:
 > RequestBody:
->     Format: ': * () ('[] *)
+>     Format: [()]
 >     ContentType: ()
 > RequestType: 'POST
 > Response:
->     Format: ': * () ('[] *)
+>     Format: [()]
 >     ContentType: ()
 
 -}
@@ -100,7 +100,7 @@ import Data.Text.Prettyprint.Doc.Render.Util.StackMachine (renderSimplyDecorated
 -- > ApiDocs ( fromList [ ( "/users/update",
 -- >                      , Details (fromList ([ ( "Response"
 -- >                                             , Details (fromList ([ ( "Format"
--- >                                                                    , Detail "': * () ('[] *)"
+-- >                                                                    , Detail "[()]"
 -- >                                                                    )
 -- >                                                                  , ( "ContentType"
 -- >                                                                    , Detail "()"
@@ -112,7 +112,7 @@ import Data.Text.Prettyprint.Doc.Render.Util.StackMachine (renderSimplyDecorated
 -- >                    , ( "/users/get",
 -- >                      , Details (fromList ([ ( "Response"
 -- >                                             , Details (fromList ([ ( "Format"
--- >                                                                    , Detail "': * () ('[] *)"
+-- >                                                                    , Detail "[()]"
 -- >                                                                    )
 -- >                                                                  , ( "ContentType"
 -- >                                                                    , Detail "()"
@@ -224,12 +224,12 @@ instance Renderable Markdown where
     render docs = Markdown m
       where m = renderSimplyDecorated id annOpen annClose docStream
             annOpen = \case
-              AnnRoute -> "### "
-              AnnParam -> "- **"
+              AnnRoute  -> "### "
+              AnnParam  -> "- **"
               AnnDetail -> "`"
             annClose = \case
-              AnnRoute -> ""
-              AnnParam -> "**"
+              AnnRoute  -> ""
+              AnnParam  -> "**"
               AnnDetail -> "`"
             docStream = layoutPretty defaultLayoutOptions docs'
             docs' = getPretty $ render docs

--- a/test/Test/Servant/Docs/Simple.hs
+++ b/test/Test/Servant/Docs/Simple.hs
@@ -4,14 +4,14 @@ module Test.Servant.Docs.Simple (mainSpec) where
 
 
 import Test.Hspec (Spec, describe, it, shouldBe)
-import Test.Servant.Docs.Simple.Samples
+import Test.Servant.Docs.Simple.Samples (ApiComplete, apiCompleteJson, apiCompletePlainText)
 
 import Servant.Docs.Simple (document, documentWith)
 import Servant.Docs.Simple.Render (Json)
 
 
 mainSpec :: Spec
-mainSpec = describe "Generates Documentation" $ do
+mainSpec = describe "document/documentWith" $ do
     it "should generate Plaintext" $
         document @ApiComplete `shouldBe` apiCompletePlainText
     it "should generate JSON" $

--- a/test/Test/Servant/Docs/Simple/Parse.hs
+++ b/test/Test/Servant/Docs/Simple/Parse.hs
@@ -5,20 +5,28 @@ module Test.Servant.Docs.Simple.Parse (parseSpec) where
 
 import Data.Map.Ordered (empty)
 import Servant.API (EmptyAPI)
+import Servant.API.ContentTypes (JSON, PlainText)
 import Test.Hspec (Spec, describe, it, shouldBe)
 
 import Test.Servant.Docs.Simple.Samples (ApiComplete, ApiMultiple, apiCompleteParsed,
                                          apiMultipleParsed)
 
-import Servant.Docs.Simple.Parse (parseApi)
+import Servant.Docs.Simple.Parse (parseApi, typeListText)
 import Servant.Docs.Simple.Render (ApiDocs (..))
 
 
 parseSpec :: Spec
-parseSpec = describe "Parses API to Document Tree" $ do
-    it "parses an EmptyAPI Details" $
-        parseApi @EmptyAPI `shouldBe` ApiDocs empty
-    it "parses all Servant API Combinators" $
-        parseApi @ApiComplete `shouldBe` apiCompleteParsed
-    it "parses an API with multiple endpoints" $
-        parseApi @ApiMultiple `shouldBe` apiMultipleParsed
+parseSpec = describe "Servant.Docs.Simple.Parse" $ do
+    describe "parseApi" $ do
+        it "parses an EmptyAPI Details" $
+            parseApi @EmptyAPI `shouldBe` ApiDocs empty
+        it "parses all Servant API Combinators" $
+            parseApi @ApiComplete `shouldBe` apiCompleteParsed
+        it "parses an API with multiple endpoints" $
+            parseApi @ApiMultiple `shouldBe` apiMultipleParsed
+    describe "typeListText" $ do
+        it "works for '[()]" $ do
+            typeListText @'[()] `shouldBe` "[()]"
+        it "works for '[JSON,PlainText]" $
+            typeListText @'[JSON,PlainText] `shouldBe` "[JSON,PlainText]"
+

--- a/test/Test/Servant/Docs/Simple/Render.hs
+++ b/test/Test/Servant/Docs/Simple/Render.hs
@@ -10,7 +10,7 @@ import Servant.Docs.Simple.Render (Json (..), PlainText (..), render)
 
 
 renderSpec :: Spec
-renderSpec = describe "Renders Details" $ do
+renderSpec = describe "render" $ do
     it "should render as JSON" $
         render @Json apiCompleteParsed `shouldBe` apiCompleteJson
     it "should render as PlainText" $

--- a/test/Test/Servant/Docs/Simple/Samples.hs
+++ b/test/Test/Servant/Docs/Simple/Samples.hs
@@ -6,9 +6,9 @@ module Test.Servant.Docs.Simple.Samples (ApiComplete, ApiMultiple, apiCompletePl
 
 import Data.Aeson (Value (String), object)
 import Data.Map.Ordered (fromList, singleton)
-import Servant.API ((:<|>), (:>), AuthProtect, BasicAuth, Capture, CaptureAll, Description, Header,
-                    HttpVersion, IsSecure, Post, QueryFlag, QueryParam, QueryParams, RemoteHost,
-                    ReqBody, StreamBody, Summary, Vault)
+import Servant.API (AuthProtect, BasicAuth, Capture, CaptureAll, Description, Header, HttpVersion,
+                    IsSecure, Post, QueryFlag, QueryParam, QueryParams, RemoteHost, ReqBody,
+                    StreamBody, Summary, Vault, (:<|>), (:>))
 
 import Text.RawString.QQ (r)
 
@@ -45,7 +45,7 @@ apiCompleteJson = Json (object [ ( "/test_route/{test::()}/{test::()}"
                                           , ( "Authentication", String "TEST_JWT")
 
                                           , ( "Response"
-                                            , object [ ( "Format", String "': * () ('[] *)")
+                                            , object [ ( "Format", String "[()]")
                                                      , ( "ContentType",String "()")
                                                      ])
 
@@ -72,7 +72,7 @@ apiCompleteJson = Json (object [ ( "/test_route/{test::()}/{test::()}"
                                           , ( "QueryFlag", object [( "Param",String "test")])
 
                                           , ( "RequestBody"
-                                            , object [ ( "Format", String "': * () ('[] *)")
+                                            , object [ ( "Format", String "[()]")
                                                      , ( "ContentType",String "()")
                                                      ])
 
@@ -102,14 +102,14 @@ QueryParams:
     Param: test
     ContentType: ()
 RequestBody:
-    Format: ': * () ('[] *)
+    Format: [()]
     ContentType: ()
 StreamBody:
     Format: ()
     ContentType: ()
 RequestType: 'POST
 Response:
-    Format: ': * () ('[] *)
+    Format: [()]
     ContentType: ()|]
 
 type ApiMultiple = "route1" :> DynRouteTest :> CaptureAllTest :> ApiDetails
@@ -166,7 +166,7 @@ apiDetails = toDetails [ ("Captures Http Version", Detail "True")
                                                             , ("ContentType", Detail "()")
                                                             ])
 
-                                , ("RequestBody", toDetails [ ("Format", Detail "': * () ('[] *)")
+                                , ("RequestBody", toDetails [ ("Format", Detail "[()]")
                                                             , ("ContentType", Detail "()")
                                                             ])
 
@@ -176,7 +176,7 @@ apiDetails = toDetails [ ("Captures Http Version", Detail "True")
 
                                 , ("RequestType", Detail "'POST")
 
-                                , ("Response", toDetails [ ("Format", Detail "': * () ('[] *)")
+                                , ("Response", toDetails [ ("Format", Detail "[()]")
                                                          , ("ContentType", Detail "()")
                                                          ])
                                 ]


### PR DESCRIPTION
Small readme fixes plus implementation of this improvement https://github.com/Holmusk/servant-docs-simple/issues/8

The idea is to recursively deconstruct the `TypeRep` using functions from [Data.Typeable](https://hackage.haskell.org/package/base-4.15.0.0/docs/Data-Typeable.html#v:splitTyConApp) and converting it to `[TypeRep]` and then showing that instead.

I executed documentation-exe in CDMP with this change and it results in this diff (just showing the beginning for illustration):


```diff
diff --git a/servant-docs-simple-before b/servant-docs-simple-after
index b885437..9c4e316 100644
--- a/servant-docs-simple-before
+++ b/servant-docs-simple-after
@@ -1,55 +1,55 @@
 ### /api/glyco/timeline/cards:
 - **Authentication**: `GLYCO_JWT`
 - **RequestBody**:
-    - **Format**: `': * Proto ('[] *)`
+    - **Format**: `[Proto]`
     - **ContentType**: `TimelineCardsRequest`
 - **RequestType**: `'POST`
 - **Response**:
-    - **Format**: `': * Proto ('[] *)`
+    - **Format**: `[Proto]`
     - **ContentType**: `TimelineCards`
 
 
 ### /api/glyco/timeline/meta:
 - **Authentication**: `GLYCO_JWT`
 - **RequestBody**:
-    - **Format**: `': * Proto ('[] *)`
+    - **Format**: `[Proto]`
     - **ContentType**: `ControlTimeline`
 - **RequestType**: `'POST`
 - **Response**:
-    - **Format**: `': * Proto ('[] *)`
+    - **Format**: `[Proto]`
     - **ContentType**: `Siblings`
 
 
 ### /api/glyco/timeline/add:
 - **Authentication**: `GLYCO_JWT`
 - **RequestBody**:
-    - **Format**: `': * Proto ('[] *)`
+    - **Format**: `[Proto]`
     - **ContentType**: `TimelineInsertionRequest`
 - **RequestType**: `'POST`
 - **Response**:
-    - **Format**: `': * Proto ('[] *)`
+    - **Format**: `[Proto]`
     - **ContentType**: `TimelineCards`
 
 
 ### /api/glyco/timeline/uploadImage:
 - **Authentication**: `GLYCO_JWT`
 - **RequestBody**:
-    - **Format**: `': * Proto ('[] *)`
+    - **Format**: `[Proto]`
     - **ContentType**: `UploadImageRequest`
 - **RequestType**: `'POST`
 - **Response**:
-    - **Format**: `': * Proto ('[] *)`
+    - **Format**: `[Proto]`
     - **ContentType**: `UploadImageResponse`
 
 
 ### /api/glyco/timeline/uploadImageDirect:
 - **Authentication**: `GLYCO_JWT`
 - **RequestBody**:
-    - **Format**: `': * Proto ('[] *)`
+    - **Format**: `[Proto]`
     - **ContentType**: `UploadImageDirectRequest`
 - **RequestType**: `'POST`
 - **Response**:
-    - **Format**: `': * Proto ('[] *)`
+    - **Format**: `[Proto]`
     - **ContentType**: `Image`
```