### PR TITLE
Allow multiple occurrences of a combinator as part of single route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,12 @@
   `HasDocumentApi` -> `HasParsableEndpoint`
   
   `parse` -> `parseApi`
+
+## 0.4.0.0
+
+* Improve how type-level lists are rendered.
+    Instead of "Format: ': * JSON ('[] *)"
+    you'll get "Format: [JSON]"
+
+* Fix bug when any given API combinator would only be rendered once per endpoint
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,3 +36,4 @@
 
 * Fix bug when any given API combinator would only be rendered once per endpoint
 
+* API change: removed `toDetails` function. Use `Details` constructor directly instead.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # servant-docs-simple
 
-[![Build status](https://img.shields.io/travis/holmusk/servant-docs-simple.svg?logo=travis?branch=master)](https://travis-ci.org/holmusk/servant-docs-simple)
+[![Build status](https://github.com/holmusk/servant-docs-simple/workflows/CI/badge.svg)](https://github.com/holmusk/servant-docs-simple/actions)
 [![Hackage](https://img.shields.io/hackage/v/servant-docs-simple.svg?logo=haskell)](https://hackage.haskell.org/package/servant-docs-simple)
 [![Stackage Lts](http://stackage.org/package/servant-docs-simple/badge/lts)](http://stackage.org/lts/package/servant-docs-simple)
 [![Stackage Nightly](http://stackage.org/package/servant-docs-simple/badge/nightly)](http://stackage.org/nightly/package/servant-docs-simple)

--- a/examples/custom.hs
+++ b/examples/custom.hs
@@ -15,7 +15,7 @@ import Data.Typeable (Typeable, typeRep)
 
 import Servant.API ((:>))
 import Servant.Docs.Simple (writeDocsPlainText)
-import Servant.Docs.Simple.Parse (HasParsableEndpoint (..), toDetails, typeText)
+import Servant.Docs.Simple.Parse (HasParsableEndpoint (..), typeText)
 import Servant.Docs.Simple.Render (Details (..))
 
 data CustomCombinator a b
@@ -23,9 +23,9 @@ data CustomCombinator a b
 -- CustomCombinator documentation
 instance (HasParsableEndpoint rest, Typeable a, Typeable b) => HasParsableEndpoint (CustomCombinator a b :> rest) where
     parseEndpoint r a = parseEndpoint @rest r $ a <> [("CustomCombinator"
-                                                     , toDetails [ ("Param A", Detail $ typeText @a)
-                                                                 , ("Param B", Detail $ typeText @b)
-                                                                 ]
+                                                     , Details [ ("Param A", Detail $ typeText @a)
+                                                               , ("Param B", Detail $ typeText @b)
+                                                               ]
                                                      )]
 
 --- Just to allow compilation

--- a/examples/render.hs
+++ b/examples/render.hs
@@ -35,15 +35,15 @@ type Information = Text
 
 -- Allow us to render the documentTree in our custom data type
 instance Renderable Documented where
-  render (ApiDocs a) = Documented a'
-    where a' = convert <$> assocs a
+  render (ApiDocs endpoints) = Documented endpoints'
+    where endpoints' = convert <$> endpoints
           convert (route, info) = Endpt route (getInfo info)
 
 -- Just mush everything together, just a proof of concept.
 -- Check out Renderable instances in Servant.Docs.Simple.Render for proper implementations
 getInfo :: Details -> Text
 getInfo (Detail t)  = t
-getInfo (Details d) = foldMap (\(t, rest) -> t <> getInfo rest) $ assocs d
+getInfo (Details ds) = foldMap (\(t, rest) -> t <> getInfo rest) ds
 
 -- Rendered data structure
 documented :: Documented

--- a/servant-docs-simple.cabal
+++ b/servant-docs-simple.cabal
@@ -1,10 +1,10 @@
 cabal-version:       2.4
 name:                servant-docs-simple
-version:             0.3.0.0
+version:             0.4.0.0
 synopsis:            Generate endpoints overview for Servant API
 
 description:
-    This library uses [Data.Typeable](http://hackage.haskell.org/package/base-4.12.0.0/docs/Data-Typeable.html)
+    This library uses [Data.Typeable](https://hackage.haskell.org/package/base/docs/Data-Typeable.html)
     to generate documentation for [Servant](https://hackage.haskell.org/package/servant) API types.
 
 

--- a/servant-docs-simple.cabal
+++ b/servant-docs-simple.cabal
@@ -35,7 +35,6 @@ source-repository head
 common common-options
   build-depends:       base >= 4.11.1.0 && < 5
                      , aeson >= 1.4.2 && < 1.6
-                     , ordered-containers >= 0.2.2 && < 0.3
                      , servant >= 0.15 && < 0.19
 
   ghc-options:         -Wall
@@ -74,7 +73,6 @@ library
                      , bytestring  >= 0.10.8.2 && < 0.12
                      , prettyprinter >= 1.6 && < 1.8
                      , text >= 1.2.3.1 && < 1.3
-                     , unordered-containers  >= 0.2.10 && < 0.3
 
   hs-source-dirs:      src
 

--- a/src/Servant/Docs/Simple/Parse.hs
+++ b/src/Servant/Docs/Simple/Parse.hs
@@ -154,8 +154,8 @@ instance HasParsableEndpoint b => HasParsableEndpoint (Vault :> b) where
 instance (HasParsableEndpoint b, KnownSymbol realm, Typeable a) => HasParsableEndpoint (BasicAuth (realm :: Symbol) a :> b) where
     parseEndpoint r a = parseEndpoint @b r $ a <> [( "Basic Authentication"
                                         , Details [ ("Realm", Detail realm)
-                                                    , ("UserData", Detail userData)
-                                                    ]
+                                                  , ("UserData", Detail userData)
+                                                  ]
                                         )]
 
         where realm = symbolVal' @realm
@@ -170,8 +170,8 @@ instance (HasParsableEndpoint b, KnownSymbol token) => HasParsableEndpoint (Auth
 instance (HasParsableEndpoint b, KnownSymbol ct, Typeable typ) => HasParsableEndpoint (Header' m (ct :: Symbol) typ :> b) where
     parseEndpoint r a = parseEndpoint @b r $ a <> [( "RequestHeaders"
                                         , Details [ ("Name", Detail $ symbolVal' @ct)
-                                                    , ("ContentType", Detail $ typeText @typ)
-                                                    ]
+                                                  , ("ContentType", Detail $ typeText @typ)
+                                                  ]
                                         )]
 
 -- | Query flag documentation
@@ -184,32 +184,32 @@ instance (HasParsableEndpoint b, KnownSymbol param) => HasParsableEndpoint (Quer
 instance (HasParsableEndpoint b, KnownSymbol param, Typeable typ) => HasParsableEndpoint (QueryParam' m (param :: Symbol) typ :> b) where
     parseEndpoint r a = parseEndpoint @b r $ a <> [( "QueryParam"
                                         , Details [ ("Param", Detail $ symbolVal' @param)
-                                                    , ("ContentType", Detail $ typeText @typ)
-                                                    ]
+                                                  , ("ContentType", Detail $ typeText @typ)
+                                                  ]
                                         )]
 
 -- | Query params documentation
 instance (HasParsableEndpoint b, KnownSymbol param, Typeable typ) => HasParsableEndpoint (QueryParams (param :: Symbol) typ :> b) where
     parseEndpoint r a = parseEndpoint @b r $ a <> [(  "QueryParams"
                                         , Details [ ("Param", Detail $ symbolVal' @param)
-                                                    , ("ContentType", Detail $ typeText @typ)
-                                                    ]
+                                                  , ("ContentType", Detail $ typeText @typ)
+                                                  ]
                                         )]
 
 -- | Request body documentation
 instance (HasParsableEndpoint b, Typeable (ct :: [Type]), Typeable typ) => HasParsableEndpoint (ReqBody' m (ct :: [Type]) typ :> b) where
     parseEndpoint r a = parseEndpoint @b r $ a <> [( "RequestBody"
                                         , Details [ ("Format", Detail $ typeListText @ct)
-                                                    , ("ContentType", Detail $ typeText @typ)
-                                                    ]
+                                                  , ("ContentType", Detail $ typeText @typ)
+                                                  ]
                                         )]
 
 -- | Stream body documentation
 instance (HasParsableEndpoint b, Typeable ct, Typeable typ) => HasParsableEndpoint (StreamBody' m ct typ :> b) where
     parseEndpoint r a = parseEndpoint @b r $ a <> [( "StreamBody"
                                         , Details [ ("Format", Detail $ typeText @ct)
-                                                    , ("ContentType", Detail $ typeText @typ)
-                                                    ]
+                                                  , ("ContentType", Detail $ typeText @typ)
+                                                  ]
                                         )]
 
 -- | Response documentation
@@ -220,8 +220,8 @@ instance (Typeable m, Typeable (ct :: [Type]), Typeable typ) => HasParsableEndpo
         where requestType = ("RequestType", Detail $ typeText @m)
               response = ( "Response"
                          , Details [ ("Format", Detail $ typeListText @ct)
-                                     , ("ContentType", Detail $ typeText @typ)
-                                     ]
+                                   , ("ContentType", Detail $ typeText @typ)
+                                   ]
                          )
 
 

--- a/src/Servant/Docs/Simple/Parse.hs
+++ b/src/Servant/Docs/Simple/Parse.hs
@@ -49,14 +49,12 @@ module Servant.Docs.Simple.Parse
        ( HasParsableEndpoint (..)
        , HasParsableApi (..)
        , symbolVal'
-       , toDetails
        , typeText
        , typeListText
        ) where
 
 
 import Data.Foldable (fold)
-import Data.Map.Ordered (OMap, empty, fromList, (|<))
 import Data.Proxy
 import Data.Text (Text, pack)
 import Data.Typeable (Typeable, typeRep, TypeRep, splitTyConApp, TyCon, tyConPackage, tyConModule, tyConName)
@@ -89,15 +87,15 @@ class HasCollatable api where
 
 -- | Collapse a type-level list of API endpoints into documentation
 instance (HasParsableEndpoint e, HasCollatable b) => HasCollatable (e ': b) where
-    collate = ApiDocs $ (Details <$> documentEndpoint @e) |< previous
+    collate = ApiDocs $ (Details <$> documentEndpoint @e) : previous
       where ApiDocs previous = collate @b
 
 -- | Terminal step when there are no more endpoints left to recurse over
 instance HasCollatable '[] where
-    collate = ApiDocs empty
+    collate = ApiDocs []
 
 -- | Folds an api endpoint into documentation
-documentEndpoint :: forall a. HasParsableEndpoint a => (Route, OMap Parameter Details)
+documentEndpoint :: forall a. HasParsableEndpoint a => (Route, [(Parameter, Details)])
 documentEndpoint = parseEndpoint @a "" []
 
 -- | Folds an api endpoint into documentation
@@ -106,7 +104,7 @@ class HasParsableEndpoint e where
     -- | We use this to destructure the API type and convert it into documentation
     parseEndpoint :: Route -- ^ Route documentation
                   -> [(Parameter, Details)] -- ^ Everything else documentation
-                  -> (Route, OMap Parameter Details) -- ^ Generated documentation for the route
+                  -> (Route, [(Parameter, Details)]) -- ^ Generated documentation for the route
 
 -- | Static route documentation
 instance (HasParsableEndpoint b, KnownSymbol route) => HasParsableEndpoint ((route :: Symbol) :> b) where
@@ -155,7 +153,7 @@ instance HasParsableEndpoint b => HasParsableEndpoint (Vault :> b) where
 -- | Basic authentication documentation
 instance (HasParsableEndpoint b, KnownSymbol realm, Typeable a) => HasParsableEndpoint (BasicAuth (realm :: Symbol) a :> b) where
     parseEndpoint r a = parseEndpoint @b r $ a <> [( "Basic Authentication"
-                                        , toDetails [ ("Realm", Detail realm)
+                                        , Details [ ("Realm", Detail realm)
                                                     , ("UserData", Detail userData)
                                                     ]
                                         )]
@@ -171,7 +169,7 @@ instance (HasParsableEndpoint b, KnownSymbol token) => HasParsableEndpoint (Auth
 -- | Request header documentation
 instance (HasParsableEndpoint b, KnownSymbol ct, Typeable typ) => HasParsableEndpoint (Header' m (ct :: Symbol) typ :> b) where
     parseEndpoint r a = parseEndpoint @b r $ a <> [( "RequestHeaders"
-                                        , toDetails [ ("Name", Detail $ symbolVal' @ct)
+                                        , Details [ ("Name", Detail $ symbolVal' @ct)
                                                     , ("ContentType", Detail $ typeText @typ)
                                                     ]
                                         )]
@@ -179,13 +177,13 @@ instance (HasParsableEndpoint b, KnownSymbol ct, Typeable typ) => HasParsableEnd
 -- | Query flag documentation
 instance (HasParsableEndpoint b, KnownSymbol param) => HasParsableEndpoint (QueryFlag (param :: Symbol) :> b) where
     parseEndpoint r a = parseEndpoint @b r $ a <> [( "QueryFlag"
-                                        , toDetails [ ("Param", Detail $ symbolVal' @param) ]
+                                        , Details [ ("Param", Detail $ symbolVal' @param) ]
                                         )]
 
 -- | Query param documentation
 instance (HasParsableEndpoint b, KnownSymbol param, Typeable typ) => HasParsableEndpoint (QueryParam' m (param :: Symbol) typ :> b) where
     parseEndpoint r a = parseEndpoint @b r $ a <> [( "QueryParam"
-                                        , toDetails [ ("Param", Detail $ symbolVal' @param)
+                                        , Details [ ("Param", Detail $ symbolVal' @param)
                                                     , ("ContentType", Detail $ typeText @typ)
                                                     ]
                                         )]
@@ -193,7 +191,7 @@ instance (HasParsableEndpoint b, KnownSymbol param, Typeable typ) => HasParsable
 -- | Query params documentation
 instance (HasParsableEndpoint b, KnownSymbol param, Typeable typ) => HasParsableEndpoint (QueryParams (param :: Symbol) typ :> b) where
     parseEndpoint r a = parseEndpoint @b r $ a <> [(  "QueryParams"
-                                        , toDetails [ ("Param", Detail $ symbolVal' @param)
+                                        , Details [ ("Param", Detail $ symbolVal' @param)
                                                     , ("ContentType", Detail $ typeText @typ)
                                                     ]
                                         )]
@@ -201,7 +199,7 @@ instance (HasParsableEndpoint b, KnownSymbol param, Typeable typ) => HasParsable
 -- | Request body documentation
 instance (HasParsableEndpoint b, Typeable (ct :: [Type]), Typeable typ) => HasParsableEndpoint (ReqBody' m (ct :: [Type]) typ :> b) where
     parseEndpoint r a = parseEndpoint @b r $ a <> [( "RequestBody"
-                                        , toDetails [ ("Format", Detail $ typeListText @ct)
+                                        , Details [ ("Format", Detail $ typeListText @ct)
                                                     , ("ContentType", Detail $ typeText @typ)
                                                     ]
                                         )]
@@ -209,7 +207,7 @@ instance (HasParsableEndpoint b, Typeable (ct :: [Type]), Typeable typ) => HasPa
 -- | Stream body documentation
 instance (HasParsableEndpoint b, Typeable ct, Typeable typ) => HasParsableEndpoint (StreamBody' m ct typ :> b) where
     parseEndpoint r a = parseEndpoint @b r $ a <> [( "StreamBody"
-                                        , toDetails [ ("Format", Detail $ typeText @ct)
+                                        , Details [ ("Format", Detail $ typeText @ct)
                                                     , ("ContentType", Detail $ typeText @typ)
                                                     ]
                                         )]
@@ -218,19 +216,14 @@ instance (HasParsableEndpoint b, Typeable ct, Typeable typ) => HasParsableEndpoi
 --   Terminates here as responses are last parts of api endpoints
 --   Note that request type information (GET, POST etc...) is contained here
 instance (Typeable m, Typeable (ct :: [Type]), Typeable typ) => HasParsableEndpoint (Verb m s (ct :: [Type]) typ) where
-    parseEndpoint r a = ( r
-                   , fromList $ a <> [requestType, response]
-                   )
+    parseEndpoint r a = (r,  a <> [requestType, response])
         where requestType = ("RequestType", Detail $ typeText @m)
               response = ( "Response"
-                         , toDetails [ ("Format", Detail $ typeListText @ct)
+                         , Details [ ("Format", Detail $ typeListText @ct)
                                      , ("ContentType", Detail $ typeText @typ)
                                      ]
                          )
 
--- | Convert parameter-value pairs to Details type
-toDetails :: [(Text, Details)] -> Details
-toDetails = Details . fromList
 
 -- | Convert types to Text
 typeText :: forall a. Typeable a => Text

--- a/test/Test/Servant/Docs/Simple/Parse.hs
+++ b/test/Test/Servant/Docs/Simple/Parse.hs
@@ -3,7 +3,6 @@
 module Test.Servant.Docs.Simple.Parse (parseSpec) where
 
 
-import Data.Map.Ordered (empty)
 import Servant.API (EmptyAPI)
 import Servant.API.ContentTypes (JSON, PlainText)
 import Test.Hspec (Spec, describe, it, shouldBe)
@@ -19,7 +18,7 @@ parseSpec :: Spec
 parseSpec = describe "Servant.Docs.Simple.Parse" $ do
     describe "parseApi" $ do
         it "parses an EmptyAPI Details" $
-            parseApi @EmptyAPI `shouldBe` ApiDocs empty
+            parseApi @EmptyAPI `shouldBe` ApiDocs []
         it "parses all Servant API Combinators" $
             parseApi @ApiComplete `shouldBe` apiCompleteParsed
         it "parses an API with multiple endpoints" $

--- a/test/Test/Servant/Docs/Simple/Samples.hs
+++ b/test/Test/Servant/Docs/Simple/Samples.hs
@@ -5,78 +5,77 @@ module Test.Servant.Docs.Simple.Samples (ApiComplete, ApiMultiple, apiCompletePl
                                          apiCompleteParsed, apiCompleteJson, apiMultipleParsed) where
 
 import Data.Aeson (Value (String), object)
-import Data.Map.Ordered (fromList, singleton)
 import Servant.API (AuthProtect, BasicAuth, Capture, CaptureAll, Description, Header, HttpVersion,
-                    IsSecure, Post, QueryFlag, QueryParam, QueryParams, RemoteHost, ReqBody,
-                    StreamBody, Summary, Vault, (:<|>), (:>))
+                    IsSecure,QueryFlag, QueryParam, QueryParams, RemoteHost, ReqBody,
+                    StreamBody, Summary, Vault, (:<|>), (:>), JSON )
+import Servant.API.Verbs (Put, Post, Patch, Get)
 
 import Text.RawString.QQ (r)
 
-import Servant.Docs.Simple.Parse (toDetails)
 import Servant.Docs.Simple.Render (ApiDocs (..), Details (..), Json (..), PlainText (..))
 
 
 type ApiComplete = StaticRouteTest :> DynRouteTest :> CaptureAllTest :> ApiDetails
 
 apiCompleteParsed :: ApiDocs
-apiCompleteParsed = ApiDocs $ curry singleton "/test_route/{test::()}/{test::()}" apiDetails
+apiCompleteParsed = ApiDocs [("/test_route/{test::()}/{test::()}", apiDetails)]
 
 apiCompleteJson :: Json
-apiCompleteJson = Json (object [ ( "/test_route/{test::()}/{test::()}"
-                                 , object [ ( "StreamBody"
-                                            , object [ ( "Format", String "()")
-                                                     , ( "ContentType", String "()")
-                                                     ])
-
-                                          , ( "Summary",String "sampleText" )
-
-                                          , ( "Basic Authentication"
-                                            , object [ ( "UserData", String "()")
-                                                     , ( "Realm", String "local")
-                                                     ])
-
-                                          , ( "Captures Http Version", String "True")
-
-                                          , ( "QueryParam"
-                                            , object [ ( "Param",String "test")
-                                                     , ( "ContentType",String "()")
-                                                     ])
-
-                                          , ( "Authentication", String "TEST_JWT")
-
-                                          , ( "Response"
-                                            , object [ ( "Format", String "[()]")
-                                                     , ( "ContentType",String "()")
-                                                     ])
-
-                                          , ( "RequestType", String "'POST")
-
-                                          , ( "Vault", String "True")
-
-                                          , ( "Captures RemoteHost/IP", String "True")
-
-                                          , ( "RequestHeaders"
-                                            , object [ ( "Name",String "test")
-                                                     , ( "ContentType",String "()")
-                                                     ])
-
-                                          , ( "SSL Only",String "True")
-
-                                          , ( "QueryParams"
-                                            , object [ ( "Param",String "test")
-                                                     , ( "ContentType",String "()")
-                                                     ])
-
-                                          , ( "Description", String "sampleText")
-
-                                          , ( "QueryFlag", object [( "Param",String "test")])
-
-                                          , ( "RequestBody"
-                                            , object [ ( "Format", String "[()]")
-                                                     , ( "ContentType",String "()")
-                                                     ])
-
-                                          ])])
+apiCompleteJson = Json $ object
+    [ ( "/test_route/{test::()}/{test::()}"
+      , object
+        [ ( "StreamBody"
+          , object [ ( "Format", String "()")
+                   , ( "ContentType", String "()")
+                   ]
+          )
+        , ( "Summary", String "sampleText")
+        , ( "Basic Authentication"
+          , object [ ( "UserData", String "()")
+                   , ( "Realm", String "local")
+                   ]
+          )
+        , ( "Captures Http Version", String "True")
+        , ( "QueryParam"
+          , object [ ( "Param",String "test1")
+                   , ( "ContentType",String "Int")
+                   ]
+          )
+        , ( "QueryParam"
+          , object [ ( "Param",String "test2")
+                   , ( "ContentType",String "Bool")
+                   ]
+          )
+        , ( "Authentication", String "TEST_JWT")
+        , ( "Response"
+          , object [ ( "Format", String "[()]")
+                   , ( "ContentType", String "()")
+                   ]
+          )
+        , ( "RequestType", String "'POST")
+        , ( "Vault", String "True")
+        , ( "Captures RemoteHost/IP", String "True")
+        , ( "RequestHeaders"
+          , object [ ( "Name",String "test")
+                   , ( "ContentType",String "()")
+                   ]
+          )
+        , ( "SSL Only", String "True")
+        , ( "QueryParams"
+          , object [ ( "Param",String "test")
+                   , ( "ContentType",String "()")
+                   ]
+          )
+        , ( "Description", String "sampleText")
+        , ( "QueryFlag", object [( "Param",String "test")])
+        , ( "RequestBody"
+          , object [ ( "Format", String "[()]")
+                   , ( "ContentType",String "()")
+                   ]
+          )
+        ]
+      )
+    ]
 
 apiCompletePlainText :: PlainText
 apiCompletePlainText = PlainText [r|/test_route/{test::()}/{test::()}:
@@ -96,8 +95,11 @@ RequestHeaders:
 QueryFlag:
     Param: test
 QueryParam:
-    Param: test
-    ContentType: ()
+    Param: test1
+    ContentType: Int
+QueryParam:
+    Param: test2
+    ContentType: Bool
 QueryParams:
     Param: test
     ContentType: ()
@@ -115,12 +117,37 @@ Response:
 type ApiMultiple = "route1" :> DynRouteTest :> CaptureAllTest :> ApiDetails
               :<|> "route2" :> DynRouteTest :> CaptureAllTest :> ApiDetails
               :<|> "route3" :> DynRouteTest :> CaptureAllTest :> ApiDetails
+              :<|> "get" :> GetTest
+              :<|> "post" :> PostTest
+              :<|> "put" :> PutTest
+              :<|> "patch" :> PatchTest
 
 apiMultipleParsed :: ApiDocs
-apiMultipleParsed = ApiDocs $ fromList [ ("/route1/{test::()}/{test::()}", apiDetails)
-                                       , ("/route2/{test::()}/{test::()}", apiDetails)
-                                       , ("/route3/{test::()}/{test::()}", apiDetails)
-                                       ]
+apiMultipleParsed = ApiDocs 
+    [ ("/route1/{test::()}/{test::()}", apiDetails)
+    , ("/route2/{test::()}/{test::()}", apiDetails)
+    , ("/route3/{test::()}/{test::()}", apiDetails)
+    , ("/get", Details [ ("RequestType", Detail "'GET")
+                       , ("Response", Details [ ("Format",Detail "[JSON]")
+                                              , ("ContentType",Detail "()")
+                                              ])
+                       ])
+    , ("/post", Details [ ("RequestType",Detail "'POST")
+                        , ("Response", Details [ ("Format",Detail "[()]")
+                                               , ("ContentType",Detail "()")
+                                               ])
+                       ])
+    , ("/put", Details [ ("RequestType",Detail "'PUT")
+                       , ("Response", Details [ ("Format",Detail "[()]")
+                                              , ("ContentType",Detail "()")
+                                              ])
+                       ])
+    , ("/patch", Details [ ("RequestType", Detail "'PATCH")
+                         , ("Response", Details [ ("Format",Detail "[()]")
+                                                , ("ContentType",Detail "()")
+                                                ])
+                         ])
+    ]
 
 
 type ApiDetails = HttpVersionTest
@@ -134,52 +161,49 @@ type ApiDetails = HttpVersionTest
                :> HeaderTest
                :> QueryFlagTest
                :> QueryParamTest
+               :> QueryParamTest2 -- Check that multiple query parameters can be included in 1 endpoint
                :> QueryParamsTest
                :> ReqBodyTest
                :> StreamBodyTest
-               :> ResponseTest
+               :> PostTest
+
 
 apiDetails :: Details
-apiDetails = toDetails [ ("Captures Http Version", Detail "True")
-                                , ("SSL Only", Detail "True")
-                                , ("Captures RemoteHost/IP", Detail "True")
-                                , ("Description", Detail "sampleText")
-                                , ("Summary", Detail "sampleText")
-                                , ("Vault", Detail "True")
-                                , ("Basic Authentication", toDetails [ ("Realm", Detail "local")
-                                                                     , ("UserData", Detail "()")
-                                                                     ])
-
-                                , ("Authentication", Detail "TEST_JWT")
-
-                                , ("RequestHeaders", toDetails [ ("Name", Detail "test")
-                                                                        , ("ContentType", Detail "()")
-                                                                        ])
-
-                                , ("QueryFlag", Details $ curry singleton "Param" (Detail "test"))
-
-                                , ("QueryParam", toDetails [ ("Param", Detail "test")
-                                                           , ("ContentType", Detail "()")
-                                                           ])
-
-                                , ("QueryParams", toDetails [ ("Param", Detail "test")
-                                                            , ("ContentType", Detail "()")
-                                                            ])
-
-                                , ("RequestBody", toDetails [ ("Format", Detail "[()]")
-                                                            , ("ContentType", Detail "()")
-                                                            ])
-
-                                , ("StreamBody", toDetails [ ("Format", Detail "()")
-                                                           , ("ContentType", Detail "()")
-                                                           ])
-
-                                , ("RequestType", Detail "'POST")
-
-                                , ("Response", toDetails [ ("Format", Detail "[()]")
-                                                         , ("ContentType", Detail "()")
-                                                         ])
-                                ]
+apiDetails = Details
+    [ ("Captures Http Version", Detail "True")
+    , ("SSL Only", Detail "True")
+    , ("Captures RemoteHost/IP", Detail "True")
+    , ("Description", Detail "sampleText")
+    , ("Summary", Detail "sampleText")
+    , ("Vault", Detail "True")
+    , ("Basic Authentication", Details [ ("Realm", Detail "local")
+                                       , ("UserData", Detail "()")
+                                       ])
+    , ("Authentication", Detail "TEST_JWT")
+    , ("RequestHeaders", Details [ ("Name", Detail "test")
+                                 , ("ContentType", Detail "()")
+                                 ])
+    , ("QueryFlag", Details [("Param", Detail "test")])
+    , ("QueryParam", Details [ ("Param", Detail "test1")
+                             , ("ContentType", Detail "Int")
+                             ])
+    , ("QueryParam", Details [ ("Param", Detail "test2")
+                             , ("ContentType", Detail "Bool")
+                             ])
+    , ("QueryParams", Details [ ("Param", Detail "test")
+                              , ("ContentType", Detail "()")
+                              ])
+    , ("RequestBody", Details [ ("Format", Detail "[()]")
+                              , ("ContentType", Detail "()")
+                              ])
+    , ("StreamBody", Details [ ("Format", Detail "()")
+                             , ("ContentType", Detail "()")
+                             ])
+    , ("RequestType", Detail "'POST")
+    , ("Response", Details [ ("Format", Detail "[()]")
+                           , ("ContentType", Detail "()")
+                           ])
+    ]
 
 type StaticRouteTest = "test_route"
 
@@ -207,7 +231,9 @@ type HeaderTest = Header "test" ()
 
 type QueryFlagTest = QueryFlag "test"
 
-type QueryParamTest = QueryParam "test" ()
+type QueryParamTest = QueryParam "test1" Int
+
+type QueryParamTest2 = QueryParam "test2" Bool
 
 type QueryParamsTest = QueryParams "test" ()
 
@@ -215,4 +241,10 @@ type ReqBodyTest = ReqBody '[()] ()
 
 type StreamBodyTest = StreamBody () ()
 
-type ResponseTest = Post '[()] ()
+type GetTest = Get '[JSON] ()
+
+type PostTest = Post '[()] ()
+
+type PutTest = Put '[()] ()
+
+type PatchTest = Patch '[()] ()


### PR DESCRIPTION
This changes the internal data structure used to accumulate information from the API specification.
Instead of `Ordered.Map Parameter Details` I'm switching back to `[(Parameter, Details)]`.
This fixes both https://github.com/Holmusk/servant-docs-simple/issues/17 and https://github.com/Holmusk/servant-docs-simple/issues/18


