### PR TITLE
Allow compilation with older versions of prettyprinter

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -69,7 +69,7 @@ jobs:
     strategy:
       matrix:
         stack: ["2.7.3"]
-        ghc: ["8.10.7"]
+        resolver: ["lts-16.31", "lts-18.10"]
 
     steps:
     - uses: actions/checkout@v2
@@ -78,26 +78,25 @@ jobs:
     - uses: haskell/actions/setup@v1
       name: Setup Haskell Stack
       with:
-        ghc-version: ${{ matrix.ghc }}
         stack-version: ${{ matrix.stack }}
 
     - uses: actions/cache@v2.1.6
       name: Cache ~/.stack
       with:
         path: ~/.stack
-        key: ${{ runner.os }}-${{ matrix.ghc }}-stack
+        key: ${{ runner.os }}-stack
 
     - name: Install dependencies
       run: |
-        stack build --test --bench --no-run-tests --no-run-benchmarks --only-dependencies
+        stack build --resolver=${{ matrix.resolver }} --test --bench --no-run-tests --no-run-benchmarks --only-dependencies
 
     - name: Build
       run: |
-        stack build --test --bench --no-run-tests --no-run-benchmarks
+        stack build --resolver=${{ matrix.resolver }} --test --bench --no-run-tests --no-run-benchmarks
 
     - name: Test
       run: |
-        stack test
+        stack test --resolver=${{ matrix.resolver }}
     - name: Run examples
       run: |
         stack examples/custom.hs

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -64,7 +64,7 @@ jobs:
         cabal test all
 
   stack:
-    name: stack / ghc ${{ matrix.ghc }}
+    name: stack / resolver ${{ matrix.resolver }} 
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -84,7 +84,7 @@ jobs:
       name: Cache ~/.stack
       with:
         path: ~/.stack
-        key: ${{ runner.os }}-stack
+        key: ${{ runner.os }}-${{ matrix.resolver }}-stack
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -86,17 +86,22 @@ jobs:
         path: ~/.stack
         key: ${{ runner.os }}-${{ matrix.resolver }}-stack
 
+    - name: configure stack
+      run: |
+        echo 'resolver: ${{ matrix.resolver }}' > stack.yaml
+
     - name: Install dependencies
       run: |
-        stack build --resolver=${{ matrix.resolver }} --test --bench --no-run-tests --no-run-benchmarks --only-dependencies
+        stack build --test --bench --no-run-tests --no-run-benchmarks --only-dependencies
 
     - name: Build
       run: |
-        stack build --resolver=${{ matrix.resolver }} --test --bench --no-run-tests --no-run-benchmarks
+        stack build --test --bench --no-run-tests --no-run-benchmarks
 
     - name: Test
       run: |
-        stack test --resolver=${{ matrix.resolver }}
+        stack test
+
     - name: Run examples
       run: |
         stack examples/custom.hs

--- a/servant-docs-simple.cabal
+++ b/servant-docs-simple.cabal
@@ -72,7 +72,7 @@ library
   import:              common-options
   build-depends:       aeson-pretty >= 0.8.7 && < 0.9
                      , bytestring  >= 0.10.8.2 && < 0.12
-                     , prettyprinter >= 1.2.1 && < 1.8
+                     , prettyprinter >= 1.6 && < 1.8
                      , text >= 1.2.3.1 && < 1.3
                      , unordered-containers  >= 0.2.10 && < 0.3
 

--- a/src/Servant/Docs/Simple/Render.hs
+++ b/src/Servant/Docs/Simple/Render.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {- | Renders the intermediate structure into common documentation formats
 
 __Example scripts__
@@ -82,9 +83,15 @@ import Data.HashMap.Strict (fromList)
 import Data.List (intersperse)
 import Data.Map.Ordered (OMap, assocs)
 import Data.Text (Text, pack)
-import Prettyprinter (Doc, annotate, defaultLayoutOptions, indent, layoutPretty, line,
-                                  pretty, vcat, vsep)
+#if MIN_VERSION_prettyprinter(1,7,0)
+import Prettyprinter (Doc, annotate, defaultLayoutOptions, indent, layoutPretty, line, pretty, vcat,
+                      vsep)
 import Prettyprinter.Render.Util.StackMachine (renderSimplyDecorated)
+#else
+import Data.Text.Prettyprint.Doc (Doc, annotate, defaultLayoutOptions, indent, layoutPretty, line,
+                                  pretty, vcat, vsep)
+import Data.Text.Prettyprint.Doc.Render.Util.StackMachine (renderSimplyDecorated)
+#endif
 
 -- | Intermediate documentation structure, a hashmap of endpoints
 --


### PR DESCRIPTION
I was too rash to fix deprecation warnings coming from prettyprinter imports.
It turns out that older version of stack lts (the one used by meadow and CDMP) still have older version of prettyprinter and don't compile with [these changes](https://github.com/Holmusk/servant-docs-simple/pull/20/files#diff-5e9a255dc94c416d8ea57759861308efb048e59401b49b5e74ed20e690f643d7L85-R87)

I used CPP to resolve these and added additional stack job to CI so we run it with both 8.8.4 and 8.10.7 based resolvers
